### PR TITLE
Add name space to topic names if name space exists

### DIFF
--- a/mujoco_ros/src/main.cpp
+++ b/mujoco_ros/src/main.cpp
@@ -100,6 +100,7 @@ void loadmodel(void)
     {
         char title[200] = "Simulate : ";
         strcat(title, m->names);
+        strcat(title, ros::this_node::getNamespace().c_str());
         glfwSetWindowTitle(window, title);
     }
 
@@ -128,23 +129,46 @@ int main(int argc, char **argv)
     sim_command_pub = nh.advertise<std_msgs::String>("/mujoco_ros_interface/sim_command_sim2con", 1);
 
     if (!use_shm)
-    {
-        //register publisher & subscriber
-        joint_set = nh.subscribe<mujoco_ros_msgs::JointSet>("/mujoco_ros_interface/joint_set", 1, jointset_callback, ros::TransportHints().tcpNoDelay(true));
-        //joint_set_mujoco = nh.subscribe<mujoco_ros_msgs::JointSet>("/mujoco_ros_interface/joint_set_mujoco",1,joint)
-
-        //with pub_mode param false, simulation states(joint states, sensor states, simulation time ... ) are published with each own publisher.
-        //But if pub_mode param is set to True, all simulation states are going to be published by one topic, so that only one callback function from controller will be triggered.
-
+    {        
         nh.param("pub_mode", pub_total_mode, false);
+        std::cout<<"Name Space: " << ros::this_node::getNamespace() << std::endl;
+
+        //register publisher & subscriber
+        char prefix[200] = "/mujoco_ros_interface";
+        char joint_set_name[200];
+        char sim_status_name[200];
+        char joint_state_name[200];
+        char sim_time_name[200];
+        char sensor_state_name[200];
+
+        strcpy(joint_set_name, prefix);
+        strcpy(sim_status_name, prefix);
+        strcpy(joint_state_name, prefix);
+        strcpy(sim_time_name, prefix);
+        strcpy(sensor_state_name, prefix);
+        if (ros::this_node::getNamespace() != "/")
+        {
+            strcat(joint_set_name, ros::this_node::getNamespace().c_str());
+            strcat(sim_status_name, ros::this_node::getNamespace().c_str());
+            strcat(joint_state_name, ros::this_node::getNamespace().c_str());
+            strcat(sim_time_name, ros::this_node::getNamespace().c_str());
+            strcat(sensor_state_name, ros::this_node::getNamespace().c_str());
+        }
+        strcat(joint_set_name, "/joint_set");
+        strcat(sim_status_name, "/sim_status");
+        strcat(joint_state_name, "/joint_states");
+        strcat(sim_time_name, "/sim_time");
+        strcat(sensor_state_name, "/sensor_states");
+
+        joint_set = nh.subscribe<mujoco_ros_msgs::JointSet>(joint_set_name, 1, jointset_callback, ros::TransportHints().tcpNoDelay(true));
 
         if (pub_total_mode)
-            sim_status_pub = nh.advertise<mujoco_ros_msgs::SimStatus>("/mujoco_ros_interface/sim_status", 1);
+            sim_status_pub = nh.advertise<mujoco_ros_msgs::SimStatus>(sim_status_name, 1);
         else
         {
-            joint_state_pub = nh.advertise<sensor_msgs::JointState>("/mujoco_ros_interface/joint_states", 1);
-            sim_time_pub = nh.advertise<std_msgs::Float32>("/mujoco_ros_interface/sim_time", 1);
-            sensor_state_pub = nh.advertise<mujoco_ros_msgs::SensorState>("/mujoco_ros_interface/sensor_states", 1);
+            joint_state_pub = nh.advertise<sensor_msgs::JointState>(joint_state_name, 1);
+            sim_time_pub = nh.advertise<std_msgs::Float32>(sim_time_name, 1);
+            sensor_state_pub = nh.advertise<mujoco_ros_msgs::SensorState>(sensor_state_name, 1);
         }
     }
     else
@@ -221,7 +245,7 @@ int main(int argc, char **argv)
     std_msgs::String pmsg;
     pmsg.data = std::string("terminate");
     sim_command_pub.publish(pmsg);
-    
+
 #ifdef COMPILE_SHAREDMEMORY
         deleteSharedMemory(shm_msg_id, mj_shm_);
 #endif


### PR DESCRIPTION
To run multiple mujoco, topics that are published in this node (ex. /mujoco_ros_interface/joint_set, /mujoco_ros_interface/sim_status) should be different for each simulation. Therefore, depend on the name space of the node, the topic names are set accordingly. For example, if the name space is "/master", the topic name is "/mujoco_ros_interface/master/joint_set". If the name space is not specified, the topic name is set to the default value, /mujoco_ros_interface/joint_set.

To set name space of the node, you can do it as follows.
  <node name="mujoco_ros" pkg="mujoco_ros" type="mujoco_ros" required="true" respawn="false" ns="master" output="screen">
    <param name="model_file" type="string" value="$(find panda_description)/franka_panda_arm.xml"/>
    <param name="pub_mode" value="$(arg pub_mode)"/>
  </node> 